### PR TITLE
docs: fix link address

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,4 +29,4 @@ Scribble is a menubar note taking app using `LocalStorage`.
 
 ### Built with
 
-- [maxogden/menubar](/maxogden/menubar)
+- [maxogden/menubar](https://github.com/maxogden/menubar)


### PR DESCRIPTION
Hey. The link to the menubar repo is not working as expected. I just changed it. [this](https://github.com/muan/scribble-electron/blob/master/maxogden/menubar) instead of [this](https://github.com/maxogden/menubar).

Nice repo, btw. Keep it up. :+1: 
