### PR TITLE
Add default background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8">
   <style type="text/css">
+  html {
+    background-color: #fff;
+  }
+
   body,
   button,
   textarea {


### PR DESCRIPTION
I noticed my "sheet" didn't look right and so I 👀'd for something I'd learned about recently re: Electron apps—not having a default background color can cause things to not look the same across platforms. 

Not exactly sure why it was ok on my laptop but not on my desktop, but I've definitely seen this happen across Mac + Windows. Anyways, it fixed my situation and is probably good to have in and think about when themes come in the future ⌛. YAY!

| Before | After |
| --- | --- |
| ![screen shot 2016-04-12 at 1 25 45 pm](https://cloud.githubusercontent.com/assets/1305617/14474629/e950f31e-00b2-11e6-8a5f-b9891c5b2db0.png) | ![screen shot 2016-04-12 at 1 25 55 pm](https://cloud.githubusercontent.com/assets/1305617/14474635/f04a54d0-00b2-11e6-8ca3-1981a51abd35.png) |

Taiwan №1
